### PR TITLE
Open / Closed Principle

### DIFF
--- a/ArdalisRating.Core/ArdalisRating.Core.csproj
+++ b/ArdalisRating.Core/ArdalisRating.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/ArdalisRating.Core/Raters/AutoPolicyRater.cs
+++ b/ArdalisRating.Core/Raters/AutoPolicyRater.cs
@@ -1,0 +1,32 @@
+﻿using ArdalisRating.Domain;
+using ArdalisRating.Logging;
+using System;
+
+namespace ArdalisRating.Core.Raters
+{
+    public class AutoPolicyRater : RaterBase
+    {
+        public AutoPolicyRater(RatingEngine engine, ConsoleLogger logger) : base(engine, logger)
+        {
+        }
+
+        public override void Rate(Policy policy)
+        {
+            _logger.Log("Rating AUTO policy...");
+            _logger.Log("Validating policy.");
+            if (string.IsNullOrEmpty(policy.Make))
+            {
+                _logger.Log("Auto policy must specify Make");
+                return;
+            }
+            if (policy.Make == "BMW")
+            {
+                if (policy.Deductible < 500)
+                {
+                    _engine.Rating = 1000m;
+                }
+                _engine.Rating = 900m;
+            }
+        }
+    }
+}

--- a/ArdalisRating.Core/Raters/LandPolicyRater.cs
+++ b/ArdalisRating.Core/Raters/LandPolicyRater.cs
@@ -1,0 +1,29 @@
+﻿using ArdalisRating.Domain;
+using ArdalisRating.Logging;
+
+namespace ArdalisRating.Core.Raters
+{
+    public class LandPolicyRater : RaterBase
+    {
+        public LandPolicyRater(RatingEngine engine, ConsoleLogger logger) : base (engine, logger)
+        {
+        }
+
+        public override void Rate(Policy policy)
+        {
+            _logger.Log("Rating LAND policy...");
+            _logger.Log("Validating policy.");
+            if (policy.BondAmount == 0 || policy.Valuation == 0)
+            {
+                _logger.Log("Land policy must specify Bond Amount and Valuation.");
+                return;
+            }
+            if (policy.BondAmount < 0.8m * policy.Valuation)
+            {
+                _logger.Log("Insufficient bond amount.");
+                return;
+            }
+            _engine.Rating = policy.BondAmount * 0.05m;
+        }
+    }
+}

--- a/ArdalisRating.Core/Raters/LifePolicyRater.cs
+++ b/ArdalisRating.Core/Raters/LifePolicyRater.cs
@@ -1,0 +1,50 @@
+﻿using ArdalisRating.Domain;
+using ArdalisRating.Logging;
+using System;
+
+namespace ArdalisRating.Core.Raters
+{
+    public class LifePolicyRater : RaterBase
+    {
+
+        public LifePolicyRater(RatingEngine engine, ConsoleLogger logger) : base(engine, logger)
+        {
+        }
+
+        public override void Rate(Policy policy)
+        {
+            _logger.Log("Rating LIFE policy...");
+            _logger.Log("Validating policy.");
+            if (policy.DateOfBirth == DateTime.MinValue)
+            {
+                _logger.Log("Life policy must include Date of Birth.");
+                return;
+            }
+            if (policy.DateOfBirth < DateTime.Today.AddYears(-100))
+            {
+                _logger.Log("Centenarians are not eligible for coverage.");
+                return;
+            }
+            if (policy.Amount == 0)
+            {
+                _logger.Log("Life policy must include an Amount.");
+                return;
+            }
+            int age = DateTime.Today.Year - policy.DateOfBirth.Year;
+            if (policy.DateOfBirth.Month == DateTime.Today.Month &&
+                DateTime.Today.Day < policy.DateOfBirth.Day ||
+                DateTime.Today.Month < policy.DateOfBirth.Month)
+            {
+                age--;
+            }
+            decimal baseRate = policy.Amount * age / 200;
+            if (policy.IsSmoker)
+            {
+                _engine.Rating = baseRate * 2;
+                return;
+            }
+            _engine.Rating = baseRate;
+        }
+
+    }
+}

--- a/ArdalisRating.Core/Raters/RaterBase.cs
+++ b/ArdalisRating.Core/Raters/RaterBase.cs
@@ -1,0 +1,19 @@
+﻿using ArdalisRating.Domain;
+using ArdalisRating.Logging;
+
+namespace ArdalisRating.Core.Raters
+{
+    public abstract class RaterBase
+    {
+        protected readonly RatingEngine _engine;
+        protected readonly ConsoleLogger _logger;
+
+        public RaterBase(RatingEngine engine, ConsoleLogger logger)
+        {
+            _engine = engine;
+            _logger = logger;
+        }
+
+        public abstract void Rate(Policy policy);
+    }
+}

--- a/ArdalisRating.Core/Raters/RaterFactory.cs
+++ b/ArdalisRating.Core/Raters/RaterFactory.cs
@@ -1,4 +1,5 @@
 ﻿using ArdalisRating.Domain;
+using System;
 
 namespace ArdalisRating.Core.Raters
 {
@@ -6,16 +7,15 @@ namespace ArdalisRating.Core.Raters
     {
         public RaterBase Create(Policy policy, RatingEngine engine)
         {
-            switch (policy.Type)
+            try
             {
-                case PolicyType.Life:
-                    return new LifePolicyRater(engine, engine.Logger);
-                case PolicyType.Land:
-                    return new LandPolicyRater(engine, engine.Logger);
-                case PolicyType.Auto:
-                    return new AutoPolicyRater(engine, engine.Logger);
-                default:
-                    return new UnknownPolicyRater(engine, engine.Logger);
+                return (RaterBase)Activator.CreateInstance(
+                    Type.GetType($"ArdalisRating.Core.Raters.{policy.Type}PolicyRater"),
+                        new object[] { engine, engine.Logger });
+            }
+            catch
+            {
+                return new UnknownPolicyRater(engine, engine.Logger);
             }
         }
     }

--- a/ArdalisRating.Core/Raters/RaterFactory.cs
+++ b/ArdalisRating.Core/Raters/RaterFactory.cs
@@ -1,0 +1,25 @@
+﻿using ArdalisRating.Domain;
+using System;
+
+namespace ArdalisRating.Core.Raters
+{
+    public class RaterFactory
+    {
+        public RaterBase Create(Policy policy, RatingEngine engine)
+        {
+            switch (policy.Type)
+            {
+                case PolicyType.Life:
+                    return new LifePolicyRater(engine, engine.Logger);
+                case PolicyType.Land:
+                    return new LandPolicyRater(engine, engine.Logger);
+                case PolicyType.Auto:
+                    return new AutoPolicyRater(engine, engine.Logger);
+                default:
+                    throw new NotImplementedException();
+                    // TODO: Implement Null Object Pattern
+                    // Logger.Log("Unknown policy type")
+            }
+        }
+    }
+}

--- a/ArdalisRating.Core/Raters/RaterFactory.cs
+++ b/ArdalisRating.Core/Raters/RaterFactory.cs
@@ -1,5 +1,4 @@
 ﻿using ArdalisRating.Domain;
-using System;
 
 namespace ArdalisRating.Core.Raters
 {
@@ -16,9 +15,7 @@ namespace ArdalisRating.Core.Raters
                 case PolicyType.Auto:
                     return new AutoPolicyRater(engine, engine.Logger);
                 default:
-                    throw new NotImplementedException();
-                    // TODO: Implement Null Object Pattern
-                    // Logger.Log("Unknown policy type")
+                    return new UnknownPolicyRater(engine, engine.Logger);
             }
         }
     }

--- a/ArdalisRating.Core/Raters/UnknownPolicyRater.cs
+++ b/ArdalisRating.Core/Raters/UnknownPolicyRater.cs
@@ -1,0 +1,18 @@
+﻿using ArdalisRating.Domain;
+using ArdalisRating.Logging;
+
+namespace ArdalisRating.Core.Raters
+{
+    public class UnknownPolicyRater : RaterBase
+    {
+        public UnknownPolicyRater(RatingEngine engine, ConsoleLogger logger)
+            : base(engine, logger)
+        {
+        }
+
+        public override void Rate(Policy policy)
+        {
+            _logger.Log("Unknown policy type");
+        }
+    }
+}

--- a/ArdalisRating.Core/RatingEngine.cs
+++ b/ArdalisRating.Core/RatingEngine.cs
@@ -1,10 +1,6 @@
-﻿using ArdalisRating.Domain;
+﻿using ArdalisRating.Core.Raters;
 using ArdalisRating.Logging;
 using ArdalisRating.Persistence;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using System;
-using System.IO;
 
 namespace ArdalisRating.Core
 {
@@ -14,14 +10,14 @@ namespace ArdalisRating.Core
     /// </summary>
     public class RatingEngine
     {
-        private ConsoleLogger Logger { get; set; } = new ConsoleLogger();
+        public ConsoleLogger Logger { get; set; } = new ConsoleLogger();
         private FilePolicySource PolicySource { get; set; } = new FilePolicySource();
         private JsonPolicySerializer PolicySerializer { get; set; } = new JsonPolicySerializer();
 
         public decimal Rating { get; set; }
 
         public void Rate()
-        {
+        { 
             Logger.Log("Starting rate.");
 
             Logger.Log("Loading policy.");
@@ -31,80 +27,10 @@ namespace ArdalisRating.Core
 
             var policy = PolicySerializer.GetPolicyFromJsonString(policyJson);
 
-            switch (policy.Type)
-            {
-                case PolicyType.Auto:
-                    Logger.Log("Rating AUTO policy...");
-                    Logger.Log("Validating policy.");
-                    if (String.IsNullOrEmpty(policy.Make))
-                    {
-                        Logger.Log("Auto policy must specify Make");
-                        return;
-                    }
-                    if (policy.Make == "BMW")
-                    {
-                        if (policy.Deductible < 500)
-                        {
-                            Rating = 1000m;
-                        }
-                        Rating = 900m;
-                    }
-                    break;
+            var factory = new RaterFactory();
 
-                case PolicyType.Land:
-                    Logger.Log("Rating LAND policy...");
-                    Logger.Log("Validating policy.");
-                    if (policy.BondAmount == 0 || policy.Valuation == 0)
-                    {
-                        Logger.Log("Land policy must specify Bond Amount and Valuation.");
-                        return;
-                    }
-                    if (policy.BondAmount < 0.8m * policy.Valuation)
-                    {
-                        Logger.Log("Insufficient bond amount.");
-                        return;
-                    }
-                    Rating = policy.BondAmount * 0.05m;
-                    break;
-
-                case PolicyType.Life:
-                    Logger.Log("Rating LIFE policy...");
-                    Logger.Log("Validating policy.");
-                    if (policy.DateOfBirth == DateTime.MinValue)
-                    {
-                        Logger.Log("Life policy must include Date of Birth.");
-                        return;
-                    }
-                    if (policy.DateOfBirth < DateTime.Today.AddYears(-100))
-                    {
-                        Logger.Log("Centenarians are not eligible for coverage.");
-                        return;
-                    }
-                    if (policy.Amount == 0)
-                    {
-                        Logger.Log("Life policy must include an Amount.");
-                        return;
-                    }
-                    int age = DateTime.Today.Year - policy.DateOfBirth.Year;
-                    if (policy.DateOfBirth.Month == DateTime.Today.Month &&
-                        DateTime.Today.Day < policy.DateOfBirth.Day ||
-                        DateTime.Today.Month < policy.DateOfBirth.Month)
-                    {
-                        age--;
-                    }
-                    decimal baseRate = policy.Amount * age / 200;
-                    if (policy.IsSmoker)
-                    {
-                        Rating = baseRate * 2;
-                        break;
-                    }
-                    Rating = baseRate;
-                    break;
-
-                default:
-                    Logger.Log("Unknown policy type");
-                    break;
-            }
+            var rater = factory.Create(policy, this);
+            rater.Rate(policy);
 
             Logger.Log("Rating completed.");
         }

--- a/OCP.md
+++ b/OCP.md
@@ -1,0 +1,100 @@
+﻿# Open / Closed Principle
+
+[Home](README.md)
+
+## Defining
+
+Software entities (classes, modules, functions, etc) should be open for extension, but closed for modification
+
+It should be possible to change the behavior of a method without editing its source code.
+
+| Open to `extension` | Closed to `modification` |
+| --- | --- |
+| New behavior can be added in the future | Changes to source or binary code are not required |
+| Code that is closed to extension has `fixed` behavior | The only way to change the behavior of code that is closed to extension is to change the code itself |
+
+Why Should Code Be Closed to Modification?
+- Less likely to introduce bugs in code we don't touch or redeploy
+- Less likely to break dependent code when we don't have to deploy updates
+- Fewer conditionals in code that is open to extension results in simpler code
+
+We need to balance that abstraction with concreteness. Abstraction adds complexity.
+
+Predict where variation is needed and apply abstraction as needed
+
+## How Can You Predict Future Changes?
+- Start concrete
+- Modify the code the first time or two
+- By the third modification, consider making the code open to extension for that axis of change
+ 
+## Typical Approaches to OCP
+### Parameters ()
+
+
+```C#
+public class DoOneThing
+{ 
+    public void Execute()
+    {
+        Console.WriteLine("Hello world.");
+    }
+}
+``` 
+
+```C#
+public class DoOneThing
+{ 
+    public void Execute(string message)
+    {
+        Console.WriteLine(message);
+    }
+}
+```
+
+### Inheritance
+
+```C#
+public class DoOneThing
+{ 
+    public virtual void Execute()
+    {
+        Console.WriteLine("Hello world.");
+    }
+}
+public class DoAnotherThing
+{ 
+    public override void Execute()
+    {
+        Console.WriteLine("Goodbye world.");
+    }
+}
+```  
+
+### Composition / Injection
+
+```C#
+public class DoOneThing
+{
+    private readonly MessageService _messageService;
+    
+    public DoOneThing(MessageService messageService)
+    {
+        _messageService = messageService; 
+    }
+
+    public virtual void Execute()
+    {
+        Console.WriteLine(_messageService.GetMessage());
+    }
+}
+```  
+
+### Extension method
+
+### Prefer implementing new features in new classes
+Why use a New Class?
+- Design class to suit problem at hand
+- Nothing in current suystem depends on it
+- Can add behavior without touching existing code
+- Can follow Single Responsibility Principle
+- Can be unit-tested

--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ A sample application used to demonstrate SOLID principles.
 The `main` branch shows the *initial* code. It's the starting point. 
 There are separate branches for each of the 5 principles. 
 
+- Open / Closed Principle [Notes](OCP.md), [Pull Request](https://github.com/s-pauls/solid-principles/pull/9), [Branch](https://github.com/s-pauls/solid-principles/tree/OCP) 
 
 Based on ardalis [example](https://github.com/ardalis/SolidSample).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ A sample application used to demonstrate SOLID principles.
 The `main` branch shows the *initial* code. It's the starting point. 
 There are separate branches for each of the 5 principles. 
 
-- Open / Closed Principle [Notes](OCP.md), [Pull Request](https://github.com/s-pauls/solid-principles/pull/9), [Branch](https://github.com/s-pauls/solid-principles/tree/OCP) 
+- Open / Closed Principle [Notes](OCP.md), [Pull Request](https://github.com/s-pauls/solid-principles/pull/12), [Branch](https://github.com/s-pauls/solid-principles/tree/OCP) 
 
 Based on ardalis [example](https://github.com/ardalis/SolidSample).

--- a/SOLIDPrinciples.sln
+++ b/SOLIDPrinciples.sln
@@ -5,6 +5,7 @@ VisualStudioVersion = 16.0.29806.167
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6895483D-2B67-460E-B5CA-DEFF69E2E6D0}"
 	ProjectSection(SolutionItems) = preProject
+		OCP.md = OCP.md
 		README.md = README.md
 		SRP.md = SRP.md
 	EndProjectSection


### PR DESCRIPTION
# Refactored switch-case into a factory of Raters using 'Factory Method' Pattern and 'Inheritance' OCP approach

We expect that our portfolio of raters is going to continue to grow.

Each case logic moved to a separate class:
- [AutoPolicyRater.cs](https://github.com/s-pauls/solid-principles/blob/OCP/ArdalisRating.Core/Raters/AutoPolicyRater.cs);
- [LandPolicyRater.cs](https://github.com/s-pauls/solid-principles/blob/OCP/ArdalisRating.Core/Raters/LandPolicyRater.cs);
- [LifePolicyRater.cs](https://github.com/s-pauls/solid-principles/blob/OCP/ArdalisRating.Core/Raters/LifePolicyRater.cs);

A Factory was created that will eliminate the need for the switch statement inside of the RatingEngine. Also, a reflection was applied and it allows to close factory from changes when some new Rate will be added
[RaterFactory.cs](https://github.com/s-pauls/solid-principles/blob/OCP/ArdalisRating.Core/Raters/RaterFactory.cs);

Null Object Pattern was implemented to minimize null check. 
[UnknownPolicyRater.cs](https://github.com/s-pauls/solid-principles/blob/OCP/ArdalisRating.Core/Raters/UnknownPolicyRater.cs);

Benefit:
The Rate method inside of [RatingEngine](https://github.com/s-pauls/solid-principles/blob/OCP/ArdalisRating.Core/RatingEngine.cs) is now open to extension of different types of policies but closed against modification. 